### PR TITLE
fixed param bug

### DIFF
--- a/R/compute_gamma0.R
+++ b/R/compute_gamma0.R
@@ -9,8 +9,8 @@
 ##' @param freq Frequencies of SNP appearances (computed using snphap)
 ##' @return The value of gamma0
 ##' @author Mary Fortune
-compute_gamma0<-function(N0,N1,W,gamma.CV,freq){
-  eta.CV<-rowSums(sweep((hcube(rep(3,length(W)))-1),MARGIN=2,gamma.CV,`*`))
+compute_gamma0<-function(N0,N1,W,gamma.W,freq){
+  eta.CV<-rowSums(sweep((hcube(rep(3,length(W)))-1),MARGIN=2,gamma.W,`*`))
   e.eta.CV<-exp(eta.CV)
   GenoProbW<-make_GenoProbList(W[1],W,freq)[[1]]
   PW<-GenoProbW[[1]]+GenoProbW[[2]]+GenoProbW[[3]]


### PR DESCRIPTION
A bug in calling code `expected_z_score` using a parameter name that was incompatible with a `compute_gamma0` 