### PR TITLE
Simulate beta as the product of the z-score and standard error

### DIFF
--- a/vignettes/intro.Rmd
+++ b/vignettes/intro.Rmd
@@ -97,7 +97,7 @@ If we need log odds ratios and standard errors, rather than simply Z scores, we 
               gamma.W=log(g1), # log odds ratios
               freq=freq, # reference haplotypes
           nrep=3)
-  betasim <- zsim / sqrt(vbetasim)
+  betasim <- zsim * sqrt(vbetasim)
 ```
 
 The simulated odds ratios should be distributed about g1:


### PR DESCRIPTION
Thanks for creating this really useful software.

When I ran the code in the vignette, I didn't get the same results as that displayed on the pkgdown site:

```
> CV
[1] "s26" "s46"
> log(g1)
[1] 0.3364722 0.1823216
> betasim[,c(which(snps==CV[1]),which(snps==CV[2]))]
         [,1]     [,2]
[1,] 408.7593 274.2540
[2,] 324.5115 270.1871
[3,] 380.7404 305.4027
```

![Screen Shot 2021-02-23 at 1 29 34 PM](https://user-images.githubusercontent.com/1608317/108890226-4e7c7900-75db-11eb-8b22-faa67ecf17f8.png)

I think this is because of how the beta is calculated:

https://github.com/chr1swallace/simGWAS/blob/7824e3b994813ce71bfaf2f755bb83470200d4b3/vignettes/intro.Rmd#L100

From reading the paper, I expected this to be the product of the z-score and standard error:

> Together with simulated Z scores, we can then back-calculate the log odds ratios as the product of simulated Z scores and standard errors.

[runsims-1kg.R](https://github.com/chr1swallace/simgwas-paper/blob/a57b2acce00caa52aba493377a725225b8f0b710/runsims-1kg.R#L82) from simgwas-paper also uses the product.

And when I switch to using the product and re-run the vignette, then I get similar results to pkgdown site:

```
> CV
[1] "s26" "s46"
> log(g1)
[1] 0.3364722 0.1823216
> betasim[,c(which(snps==CV[1]),which(snps==CV[2]))]
          [,1]      [,2]
[1,] 0.3824336 0.1954694
[2,] 0.3067039 0.1849522
[3,] 0.3533380 0.2147012
```

Should the beta be calculated as the product, or am I misunderstanding the values returned by `simulated_vbeta()`? I saw that in a previous commit, you switched from the product to division.

https://github.com/chr1swallace/simGWAS/commit/a4c1cd5a064cc1215891f0ed95c2216466e32d25#diff-a730366300becababcaddb119e02ae61f94bc574b80176e42f6a09e83e349adbR99

I installed the package from GitHub with `remotes::install_github("chr1swallace/simGWAS")`, which installed version 0.2.0-3.

<details>

<summary><code>sessionInfo()</code></summary>

```
R version 3.6.1 (2019-07-05)
Platform: x86_64-pc-linux-gnu (64-bit)
Running under: Debian GNU/Linux 9 (stretch)

Matrix products: default
BLAS/LAPACK: /usr/lib/libopenblasp-r0.2.19.so

locale:
 [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C               LC_TIME=en_US.UTF-8       
 [4] LC_COLLATE=en_US.UTF-8     LC_MONETARY=en_US.UTF-8    LC_MESSAGES=C             
 [7] LC_PAPER=en_US.UTF-8       LC_NAME=C                  LC_ADDRESS=C              
[10] LC_TELEPHONE=C             LC_MEASUREMENT=en_US.UTF-8 LC_IDENTIFICATION=C       

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] simGWAS_0.2.0-3

loaded via a namespace (and not attached):
 [1] Rcpp_1.0.3       mvtnorm_1.1-0    corpcor_1.6.9    crayon_1.3.4     packrat_0.5.0    dplyr_0.8.4     
 [7] assertthat_0.2.1 R6_2.4.1         magrittr_1.5     pillar_1.4.3     rlang_0.4.10     rstudioapi_0.11 
[13] combinat_0.0-8   tools_3.6.1      glue_1.3.1       purrr_0.3.3      xfun_0.12        compiler_3.6.1  
[19] pkgconfig_2.0.3  tidyselect_1.0.0 knitr_1.28       tibble_2.1.3   
```

</details>