### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,46 @@
+# For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
+# https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
+on:
+  push:
+  pull_request:
+
+name: R-CMD-check
+
+jobs:
+  R-CMD-check:
+
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@v1
+
+      - name: Install libgit2-dev
+        run: sudo apt install -qq libgit2-dev
+
+      - name: Install libcurl4-openssl-dev
+        run: sudo apt install -qq libcurl4-openssl-dev
+
+      - name: Install dependencies
+        run: |
+          install.packages(c("remotes", "rcmdcheck"))
+          remotes::install_deps(dependencies = TRUE)
+          remotes::install_cran("covr")
+          remotes::install_cran("lintr")
+          remotes::install_github("MangoTheCat/goodpractice")
+        shell: Rscript {0}
+
+      - name: Check
+        run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "error")
+        shell: Rscript {0}
+
+      - name: Test coverage
+        run: covr::codecov()
+        shell: Rscript {0}
+        
+      - name: Lint
+        run: lintr::lint_package()
+        shell: Rscript {0}
+

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,6 +32,7 @@ Imports:
     mvtnorm
 RoxygenNote: 6.1.1
 Suggests: knitr,
+    markdown,
     rmarkdown,
     testthat
 VignetteBuilder: knitr


### PR DESCRIPTION
Hi @chr1swallace,

To address the problem of getting the CRAN Solaris build running, I needed to verify that the package builds under, for example, Linux. Adding this GitHub Action script allows one to do just that: every `git push`, the package is built. It is now able to add those fancy build badges ([examples here](https://github.com/ropensci/beautier#beautier))!

If you accept, I do volunteer to add those badges, but mostly, afterwards, I will see if I can get the CRAN build up again.